### PR TITLE
issue 8

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -154,6 +154,8 @@ class Products(ViewSet):
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
             return Response(serializer.data)
+        except Product.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -96,5 +96,19 @@ class ProductTests(APITestCase):
         self.assertEqual(len(json_response), 3)
 
     # TODO: Delete product
+    def test_delete_product(self):
+        """
+        Ensure we can delete a product
+        """
+        self.test_create_product()
+        url = "/products/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        # GET GAME AGAIN TO VERIFY 404 response
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- wrote a test to test delete
- asserts the 204 code on delete
- asserts the 404 on the get after the delete
- had to add an exception Product.doesnotexist to the retrieve function that returns a 404

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite



## Related Issues

- Fixes #8 