### PR TITLE
issue 9

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -56,6 +56,10 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+
+        except Payment.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -108,7 +108,7 @@ class OrderTests(APITestCase):
         url = "/orders/1"
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)
-        self.assertEqual(json_response['payment_type'], "http://localhost:8000/paymenttypes/1")
+        self.assertEqual(json_response['payment_type'], "http://testserver/paymenttypes/1")
 
 
     # TODO: New line item is not added to closed order

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -40,4 +40,20 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        """
+        Ensure we can delete a payment type for a customer
+        """
+        #add payment type
+        self.test_create_payment_type()
+
+        #delete payment type
+        url= "/paymenttypes/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        #get payment type
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- changed the retrieve in paymenttype view to throw 404 if payment.doesnotexist
- added test to payment type to check if paymenttype can be deleted
- asserts 204 no content on delete
- asserst 404 on retrieve after the item has been deleted

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite



## Related Issues

- Fixes #9 